### PR TITLE
fix: remove irregular spacing from title header

### DIFF
--- a/src/app/summary/[...path]/components/historythread.tsx
+++ b/src/app/summary/[...path]/components/historythread.tsx
@@ -17,7 +17,7 @@ const DiscussionHistory = ({
 }) => {
   return (
     <div className="relative">
-      <h2 className="font-inika text-3xl sticky top-[98px] py-6 bg-gradient-to-b from-[#fff] via-[#fff] via-70% to-[rgba(256,0,0, 1)] z-10 border-t-2">
+      <h2 className="font-inika text-3xl sticky top-[64px] md:top-[80px] py-6 bg-gradient-to-b from-[#fff] via-[#fff] via-70% to-[rgba(256,0,0, 1)] z-10 border-t-2">
         Discussion History
       </h2>
       <div id="discussion-history" className="pt-[98px] mt-[-98px]">


### PR DESCRIPTION
- Remove irregular spacing from the discussion history header when the user scrolls to see more replies