### PR TITLE
fix(WIP): descrepancy with newsletter replies

### DIFF
--- a/src/app/components/server/newsletter.tsx
+++ b/src/app/components/server/newsletter.tsx
@@ -11,6 +11,7 @@ import { MarkdownWrapper } from "./MarkdownWrapper";
 export const NewsletterCard = ({ entry }: { entry: NewsLetter }) => {
   const publishedAtDateDisplay = formattedDate(entry.published_at);
   const path = entry.combined_summ_file_path.length ? entry.combined_summ_file_path : entry.file_path;
+  // console.log({path});
   const type = entry.dev_name;
 
   return (

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -3,6 +3,7 @@ import { NewsLetterDataType, NewsLetterSet } from "@/helpers/types";
 import { NewsletterPage } from "../components/server/newsletter";
 import Link from "next/link";
 import { formattedDate } from "@/helpers/utils";
+import { getSummaryData } from "../summary/[...path]/page";
 
 // get most recent newsletter from newsletter.json
 const getCurrentNewsletter = () => {
@@ -12,6 +13,39 @@ const getCurrentNewsletter = () => {
       "utf-8"
     );
     const parsedData = JSON.parse(data) as NewsLetterDataType;
+    // console.log(parsedData.active_posts_this_week[0].file_path);
+      // get file path if present. if absent use combined_summ_file_path.
+      const getFilePath = () => {
+        // merge all posts into one array
+        const allPosts = [...parsedData.active_posts_this_week, ...parsedData.new_threads_this_week];
+        // get the file path of all posts in the array
+        const filePaths = allPosts.map((post) => {
+          console.log({ post });
+          if (post.contributors.length > 0) return post.combined_summ_file_path
+          return post.file_path
+      });
+        // console.log(filePaths);
+        // read the content of the file in the file path
+        for (let i = 0; i < filePaths.length; i++) {
+          // remove https://tldr.bitcoinsearch.xyz/summary/ from the file path if present
+          const file = filePaths[i].replace("https://tldr.bitcoinsearch.xyz/summary/", "");
+          // const path = `${process.cwd()}/public/static/static/${file}.xml`;
+          // // console.log({path});
+          // if (fs.existsSync(path)) {
+          //   const data = fs.readFileSync(path, "utf-8");
+          //   return data;
+          // }
+          // console.log({file});
+          const summaryData = getSummaryData([file]).then((data) => {
+            const authorLength = data?.data.authors.length;
+            const title = data?.data.title;
+            console.log("length", data?.month, data?.year, data?.data.authors.length, data?.data.title)
+            // console.log({authorLength, title});
+          });
+          // console.log({summaryData});
+        }
+      };
+      console.log("post got here", getFilePath());
     return parsedData;
   } catch (err) {
     return null;

--- a/src/app/summary/[...path]/page.tsx
+++ b/src/app/summary/[...path]/page.tsx
@@ -1,8 +1,7 @@
 import { convertXmlToText } from "@/helpers/convert-from-xml";
-import { addSpaceAfterPeriods, formattedDate, removeZeros } from "@/helpers/utils";
+import { formattedDate, removeZeros } from "@/helpers/utils";
 import { AuthorData } from "@/helpers/types";
 import * as fs from "fs";
-import Image from "next/image";
 import DiscussionHistory from "./components/historythread";
 import Link from "next/link";
 import BreadCrumbs from "./components/BreadCrumb";
@@ -10,7 +9,7 @@ import { MarkdownWrapper } from "@/app/components/server/MarkdownWrapper";
 
 export type sortedAuthorData = AuthorData & { initialIndex: number; dateInMS: number };
 
-const getSummaryData = async (path: string[]) => {
+export const getSummaryData = async (path: string[]) => {
   const pathString = path.join("/");
   try {
     const fileContent = fs.readFileSync(`${process.cwd()}/public/static/static/${pathString}.xml`, "utf-8");


### PR DESCRIPTION
This pr is a temporary fix to issue #242 
Here we choose not to use the `n-threads` from the backend due to data inconsistency but compute the author length from the source i.e. combined summary (or file path if a combined summary is not present).
The goal however should be to fix the issue from the backend instead of this extra computation from the frontend.